### PR TITLE
Fix Stripe India compliance and 3DS iframe bugs

### DIFF
--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -521,7 +521,7 @@ class PaymentIntentFactory:
             'payment_method_types': [method],
             'confirmation_method': confirmation_method,
             'confirm': True,
-            'description': f"{event.name}-{payment.order.code}",
+            'description': f"{event.slug.upper()}-{payment.order.code}",
             'metadata': {
                 "order": str(payment.order.id),
                 "event": event.id,
@@ -539,10 +539,24 @@ class PaymentIntentFactory:
             ),
             'expand': ["latest_charge"]
         }
+        try:
+            if hasattr(payment.order, 'invoice_address') and payment.order.invoice_address:
+                ia = payment.order.invoice_address
+                base_params['shipping'] = {
+                    'name': ia.name or payment.order.email or 'Customer',
+                    'address': {
+                        'line1': ia.street or 'N/A',
+                        'city': ia.city or 'N/A',
+                        'postal_code': ia.zipcode or '00000',
+                        'country': getattr(ia.country, 'code', str(ia.country)) or 'IN',
+                    }
+                }
+        except Exception:
+            pass
         base_params.update(kwargs)
         return stripe.PaymentIntent.create(**base_params)
 
-    def retrieve_payment_intent(payment_info, kwargs):
+    def retrieve_payment_intent(self, payment_info, **kwargs):
         return stripe.PaymentIntent.retrieve(
             payment_info['id'],
             expand=["latest_charge"],
@@ -840,7 +854,7 @@ class StripeMethod(BasePaymentProvider):
                 payment_method_types=[self.method],
                 confirmation_method=self.confirmation_method,
                 confirm=True,
-                description=f"{self.event.name}-{payment.order.code}",
+                description=f"{self.event.slug.upper()}-{payment.order.code}",
                 metadata={
                     "order": str(payment.order.id),
                     "event": self.event.id,
@@ -1263,7 +1277,7 @@ class StripeCreditCard(StripeMethod):
             else:
                 payment_info = json.loads(payment.info)
                 if not intent:
-                    intent = self.intent_factory.retrieve_payment_intent(payment_info)
+                    intent = self.intent_factory.retrieve_payment_intent(payment_info, **self.api_config)
 
         except stripe.error.CardError as e:
             self.error_handler.handle_card_error(e, payment)

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -551,8 +551,8 @@ class PaymentIntentFactory:
                         'country': getattr(ia.country, 'code', str(ia.country)) or 'IN',
                     }
                 }
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Could not set shipping information for payment intent: %s", str(e))
         base_params.update(kwargs)
         return stripe.PaymentIntent.create(**base_params)
 

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -553,6 +553,9 @@ class PaymentIntentFactory:
                 }
         except Exception as e:
             logger.warning("Could not set shipping information for payment intent: %s", str(e))
+            raise PaymentException(
+                _("Could not extract shipping information from the order. This is required for payment compliance.")
+            )
         base_params.update(kwargs)
         return stripe.PaymentIntent.create(**base_params)
 

--- a/eventyay_stripe/static/plugins/stripe/eventyay-stripe.js
+++ b/eventyay_stripe/static/plugins/stripe/eventyay-stripe.js
@@ -279,7 +279,7 @@ var stripeObj = {
             $('#scacontainer iframe').on("load", function () {
                 waitingDialog.hide();
             });
-        } else if (payment_intent_redirect_action_handling === 'redirect') {
+        } else if (payment_intent_redirect_action_handling === 'redirect' || payment_intent_redirect_action_handling === 'iframe') {
             window.location.href = payment_intent_next_action_redirect_url;
         }
     },
@@ -334,9 +334,15 @@ $(function () {
         let url = $.trim($("#order_url").html())
         // show message
         if (payment_intent_redirect_action_handling === 'iframe') {
-            window.parent.postMessage('3DS-authentication-complete.' + stt, '*');
-            return;
-        } else if (payment_intent_redirect_action_handling === 'redirect') {
+            if (window !== window.parent) {
+                window.parent.postMessage('3DS-authentication-complete.' + stt, '*');
+                return;
+            } else {
+                payment_intent_redirect_action_handling = 'redirect';
+            }
+        }
+        
+        if (payment_intent_redirect_action_handling === 'redirect') {
             waitingDialog.show(gettext("Confirming your payment …"));
             if (stt === 'p') {
                 window.location.href = url + '?paid=yes';

--- a/eventyay_stripe/static/plugins/stripe/eventyay-stripe.js
+++ b/eventyay_stripe/static/plugins/stripe/eventyay-stripe.js
@@ -335,7 +335,7 @@ $(function () {
         // show message
         if (payment_intent_redirect_action_handling === 'iframe') {
             if (window !== window.parent) {
-                window.parent.postMessage('3DS-authentication-complete.' + stt, '*');
+                window.parent.postMessage('3DS-authentication-complete.' + stt, window.location.origin);
                 return;
             } else {
                 payment_intent_redirect_action_handling = 'redirect';
@@ -369,6 +369,9 @@ $(function () {
     }
 
     $(window).on("message onmessage", function(e) {
+        if (e.originalEvent.origin !== window.location.origin) {
+            return;
+        }
         if (typeof e.originalEvent.data === "string" && e.originalEvent.data.startsWith('3DS-authentication-complete.')) {
             waitingDialog.show(gettext("Confirming your payment …"));
             $('#scacontainer').hide();

--- a/eventyay_stripe/tests/test_provider.py
+++ b/eventyay_stripe/tests/test_provider.py
@@ -77,7 +77,7 @@ def test_perform_success(env, factory, monkeypatch):
         assert kwargs['amount'] == 1337
         assert kwargs['currency'] == 'eur'
         assert kwargs['payment_method'] == 'pm_189fTT2eZvKYlo2CvJKzEzeu'
-        assert kwargs['description'] == 'Mega Conf-FOOBAR'
+        assert kwargs['description'] == 'DUMMY-FOOBAR'
         assert kwargs['statement_descriptor_suffix'] == 'DUMMY-FOOBAR Mega Conf'
         c = MockedPaymentintent()
         c.status = 'succeeded'
@@ -147,7 +147,7 @@ def test_payment_intent_description_uses_raw_event_name(env, monkeypatch):
         },
     )
 
-    assert captured['description'] == 'Mega Conf-FOOBAR'
+    assert captured['description'] == 'DUMMY-FOOBAR'
     assert captured['statement_descriptor_suffix'] == 'DUMMY-FOOBAR Mega Conf'
 
 


### PR DESCRIPTION
Close : #28

Adds shipping field to PaymentIntent for Indian export regulations and fixes JS redirect fallback for 3DS challenges in live mode.

Working demo at : https://github.com/fossasia/eventyay/pull/4791#issuecomment-5226450083

## Summary by Sourcery

Ensure Stripe payments meet Indian shipping-data requirements and reliably complete 3DS authentication across iframe and redirect flows.

Bug Fixes:
- Include invoice address shipping information in Stripe PaymentIntents to support Indian export compliance.
- Fix 3DS authentication fallback behavior for iframe and live-mode redirect flows.
- Restrict 3DS iframe completion messages to the same origin.

Enhancements:
- Use normalized event slugs in Stripe payment descriptions and improve PaymentIntent retrieval configuration handling.

Tests:
- Update Stripe provider tests for event-slug-based payment descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Payment descriptions now use the event slug for clearer Stripe transaction identification.
  - Shipping details from the invoice address are included with payment intents when available.

- **Bug Fixes**
  - Improved 3D Secure payment handling to redirect correctly when iframe-based processing is unavailable or unsupported.
  - Enhanced payment intent retrieval across supported payment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->